### PR TITLE
Swagger UI supports the ability to disable the swagger validation che…

### DIFF
--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -15,10 +15,8 @@
  */
 package io.federecio.dropwizard.swagger;
 
-import java.util.Map;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableMap;
-
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.assets.AssetsBundle;
@@ -26,6 +24,9 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.jaxrs.listing.ApiListingResource;
+
+import java.util.Map;
 
 /**
  * A {@link io.dropwizard.ConfiguredBundle} that provides hassle-free configuration of Swagger and Swagger UI
@@ -57,13 +58,14 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
         ConfigurationHelper configurationHelper = new ConfigurationHelper(configuration, swaggerBundleConfiguration);
         new AssetsBundle(Constants.SWAGGER_RESOURCES_PATH, configurationHelper.getSwaggerUriPath(), null, Constants.SWAGGER_ASSETS_NAME).run(environment);
 
-        environment.jersey().register(new SwaggerResource(configurationHelper.getUrlPattern()));
+        environment.jersey().register(new SwaggerResource(configurationHelper.getUrlPattern(), swaggerBundleConfiguration.isValidationUrlDisabled()));
+        environment.getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         setUpSwagger(swaggerBundleConfiguration, configurationHelper.getUrlPattern());
-        environment.jersey().register(io.swagger.jaxrs.listing.ApiListingResource.class);
-        environment.jersey().register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+        environment.jersey().register(new ApiListingResource());
     }
 
+    @SuppressWarnings("unused")
     protected abstract SwaggerBundleConfiguration getSwaggerBundleConfiguration(T configuration);
 
     private void setUpSwagger(SwaggerBundleConfiguration swaggerBundleConfiguration, String urlPattern) {

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
@@ -57,6 +57,9 @@ public class SwaggerBundleConfiguration {
     @JsonProperty
     private String licenseUrl;
 
+    @JsonProperty
+    private boolean isValidationUrlDisabled;
+
     /**
      * For most of the scenarios this property is not needed.
      * <p/>
@@ -141,6 +144,14 @@ public class SwaggerBundleConfiguration {
         this.uriPrefix = uriPrefix;
     }
 
+    public boolean isValidationUrlDisabled() {
+        return isValidationUrlDisabled;
+    }
+
+    public void setIsValidationUrlDisabled(final boolean isValidationUrlDisabled) {
+        this.isValidationUrlDisabled = isValidationUrlDisabled;
+    }
+
     @Override
     public String toString() {
         return "SwaggerBundleConfiguration{" +
@@ -152,6 +163,7 @@ public class SwaggerBundleConfiguration {
                 ", contact='" + contact + '\'' +
                 ", license='" + license + '\'' +
                 ", licenseUrl='" + licenseUrl + '\'' +
+                ", isValidationUrlDisabled='" + isValidationUrlDisabled + '\'' +
                 '}';
     }
 }

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerResource.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerResource.java
@@ -27,13 +27,15 @@ import javax.ws.rs.core.MediaType;
 @Produces(MediaType.TEXT_HTML)
 public class SwaggerResource {
     private final String urlPattern;
+    private final boolean isValidationUrlDisabled;
 
-    public SwaggerResource(String urlPattern) {
+    public SwaggerResource(String urlPattern, final boolean isValidationUrlDisabled) {
         this.urlPattern = urlPattern;
+        this.isValidationUrlDisabled = isValidationUrlDisabled;
     }
 
     @GET
     public SwaggerView get() {
-        return new SwaggerView(urlPattern);
+        return new SwaggerView(urlPattern, isValidationUrlDisabled);
     }
 }

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerView.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerView.java
@@ -29,8 +29,9 @@ public class SwaggerView extends View {
 
     private final String swaggerAssetsPath;
     private final String contextPath;
+    private boolean isValidationUrlDisabled;
 
-    protected SwaggerView(String urlPattern) {
+    protected SwaggerView(String urlPattern, final boolean isValidationUrlDisabled) {
         super("index.ftl", Charsets.UTF_8);
 
         if (urlPattern.equals("/")) {
@@ -44,6 +45,8 @@ public class SwaggerView extends View {
         } else {
             contextPath = urlPattern;
         }
+
+        this.isValidationUrlDisabled = isValidationUrlDisabled;
     }
 
     /**
@@ -58,5 +61,10 @@ public class SwaggerView extends View {
      */
     public String getContextPath() {
         return contextPath;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean isValidationUrlDisabled() {
+        return isValidationUrlDisabled;
     }
 }

--- a/src/main/resources/io/federecio/dropwizard/swagger/index.ftl
+++ b/src/main/resources/io/federecio/dropwizard/swagger/index.ftl
@@ -25,6 +25,9 @@
     $(function () {
       window.swaggerUi = new SwaggerUi({
         url: "${contextPath}/swagger.json",
+        <#if validationUrlDisabled>
+        validatorUrl: null,
+        </#if>
         dom_id: "swagger-ui-container",
         supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
         onComplete: function(swaggerApi, swaggerUi){


### PR DESCRIPTION
Swagger UI supports the ability to disable the swagger validation check - as we use internal API's this always fails. This is to disable that feature.

Specify in the config:

isValidationUrlDisabled: true
