### PR TITLE
Use configured Dropwizard ObjectMapper for building model schema

### DIFF
--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -25,6 +25,8 @@ import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
+import io.swagger.converter.ModelConverters;
+import io.swagger.jackson.ModelResolver;
 import io.swagger.jaxrs.config.BeanConfig;
 
 /**
@@ -45,6 +47,7 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
                 return ImmutableMap.of();
             }
         });
+        ModelConverters.getInstance().addConverter(new ModelResolver(bootstrap.getObjectMapper()));
     }
 
     @Override


### PR DESCRIPTION
By default, any changes to the Dropwizard ObjectMapper aren't
 reflected in the swagger UI. This fix ensures the displayed
 model & schema in swagger UI matches what is actually
 accepted/returned by making Swagger use the Dropwizard
 ObjectMapper for model conversion.