### PR TITLE
add 'enabled' flag so deployments can have swagger selectively disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,5 @@ Contributors
 * Tristan Burch [tburch] (https://github.com/tburch)
 * Matt Carrier [mattcarrier] (https://github.com/mattcarrier)
 * Justin Plock [jplock] (https://github.com/jplock)
+* Ian Rogers [IanRogers-LShift] (https://github.com/IanRogers-LShift)
 

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -49,6 +49,10 @@ public abstract class SwaggerBundle<T extends Configuration>
                     "You need to provide an instance of SwaggerBundleConfiguration");
         }
 
+        if (! swaggerBundleConfiguration.isEnabled()) {
+            return;
+        }
+
         final ConfigurationHelper configurationHelper = new ConfigurationHelper(
                 configuration, swaggerBundleConfiguration);
         new AssetsBundle("/swagger-static",

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
@@ -48,6 +48,7 @@ public class SwaggerBundleConfiguration {
     private Boolean prettyPrint = true;
     private String host;
     private String[] schemes = new String[] { "http" };
+    private Boolean enabled = true;
 
     /**
      * For most of the scenarios this property is not needed.
@@ -192,6 +193,16 @@ public class SwaggerBundleConfiguration {
     @JsonProperty
     public void setSchemes(String[] schemes) {
         this.schemes = schemes;
+    }
+
+    @JsonProperty
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @JsonProperty
+    public void setIsEnabled(final boolean isEnabled) {
+        this.enabled = isEnabled;
     }
 
     @JsonIgnore

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithNoSwaggerTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithNoSwaggerTest.java
@@ -14,9 +14,13 @@
 package io.federecio.dropwizard.swagger;
 
 import org.junit.ClassRule;
+import org.junit.Test;
 
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultServerWithNoSwaggerTest extends DropwizardNoSwaggerTest {
 
@@ -27,5 +31,17 @@ public class DefaultServerWithNoSwaggerTest extends DropwizardNoSwaggerTest {
 
     public DefaultServerWithNoSwaggerTest() {
         super(RULE.getLocalPort(), "/");
+    }
+
+    @Test
+    public void testEnabledConfig() {
+        final SwaggerBundleConfiguration config = new SwaggerBundleConfiguration();
+
+        // true be default
+        assertTrue(config.isEnabled());
+
+        // can be overridden
+        config.setIsEnabled(false);
+        assertFalse(config.isEnabled());
     }
 }

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithNoSwaggerTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithNoSwaggerTest.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.federecio.dropwizard.swagger;
+
+import org.junit.ClassRule;
+
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+
+public class DefaultServerWithNoSwaggerTest extends DropwizardNoSwaggerTest {
+
+    @ClassRule
+    public static final DropwizardAppRule<TestConfiguration> RULE = new DropwizardAppRule<TestConfiguration>(
+            TestApplication.class,
+            ResourceHelpers.resourceFilePath("test-default-disabled.yaml"));
+
+    public DefaultServerWithNoSwaggerTest() {
+        super(RULE.getLocalPort(), "/");
+    }
+}

--- a/src/test/java/io/federecio/dropwizard/swagger/DropwizardCommonTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DropwizardCommonTest.java
@@ -1,6 +1,5 @@
+// Copyright (C) 2014 Federico Recio
 /**
- * Copyright (C) 2014 Federico Recio
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/test/java/io/federecio/dropwizard/swagger/DropwizardCommonTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DropwizardCommonTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2014 Federico Recio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.federecio.dropwizard.swagger;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+
+import com.jayway.restassured.RestAssured;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.swagger.jaxrs.listing.BaseApiListingResource;
+
+public abstract class DropwizardCommonTest {
+
+    protected final int port;
+    protected final Path basePath;
+
+    protected DropwizardCommonTest(int port, String basePath) {
+        this.port = port;
+        this.basePath = Path.from(basePath);
+    }
+
+    @Before
+    public void setPort() {
+        RestAssured.port = port;
+    }
+
+    @BeforeClass
+    public static void crap() throws Exception {
+        Field initialized = BaseApiListingResource.class
+                .getDeclaredField("initialized");
+        initialized.setAccessible(true);
+    }
+
+    @Test
+    public void resourceIsAvailable() throws Exception {
+        RestAssured.expect().statusCode(HttpStatus.OK_200).when()
+                .get(Path.from(basePath, "test.json"));
+    }
+
+    static class Path {
+        private final List<String> pathComponents = new ArrayList<>();
+
+        public static Path from(String basePath) {
+            final Path path = new Path();
+            path.pathComponents.addAll(
+                    Splitter.on("/").omitEmptyStrings().splitToList(basePath));
+            return path;
+        }
+
+        public static String from(Path basePath, String additionalPath) {
+            final List<String> pathComponents = new ArrayList<>();
+            pathComponents.addAll(basePath.pathComponents);
+            pathComponents.add(additionalPath);
+            return asString(pathComponents);
+        }
+
+        public static String asString(List<String> pathComponents) {
+            return pathComponents.isEmpty() ? "/"
+                    : Joiner.on("/").join(pathComponents);
+        }
+    }
+}

--- a/src/test/java/io/federecio/dropwizard/swagger/DropwizardNoSwaggerTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DropwizardNoSwaggerTest.java
@@ -1,4 +1,3 @@
-// Copyright (C) 2014 Federico Recio
 /**
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,21 +19,19 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.core.StringContains;
 import org.junit.Test;
 
-public abstract class DropwizardTest extends DropwizardCommonTest {
+public abstract class DropwizardNoSwaggerTest extends DropwizardCommonTest {
 
-    protected DropwizardTest(int port, String basePath) {
+    protected DropwizardNoSwaggerTest(int port, String basePath) {
         super(port, basePath);
     }
 
     @Test
     public void swaggerIsAvailable() throws Exception {
-        RestAssured.expect().statusCode(HttpStatus.OK_200)
-                .body(StringContains
-                        .containsString(TestResource.OPERATION_DESCRIPTION))
-                .when().get(Path.from(basePath, "swagger.json"));
-        RestAssured.expect().statusCode(HttpStatus.OK_200).when()
+        RestAssured.expect().statusCode(HttpStatus.NOT_FOUND_404).when()
+                .get(Path.from(basePath, "swagger.json"));
+        RestAssured.expect().statusCode(HttpStatus.NOT_FOUND_404).when()
                 .get(Path.from(basePath, "swagger"));
-        RestAssured.expect().statusCode(HttpStatus.OK_200).when()
+        RestAssured.expect().statusCode(HttpStatus.NOT_FOUND_404).when()
                 .get(Path.from(basePath, "swagger") + "/");
     }
 

--- a/src/test/resources/test-default-disabled.yaml
+++ b/src/test/resources/test-default-disabled.yaml
@@ -1,0 +1,11 @@
+server:
+  type: default
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0
+swagger:
+  resourcePackage: io.federecio.dropwizard.swagger
+  enabled: false


### PR DESCRIPTION
Some deployments want to have swagger enabled for dev instances for internal teams, but disabled in production.

dropwizard-swagger is integrated in the initialize phase in dropwizard where the app configuration is not available. So I've added an "enabled" flag (default true) to dropwizard-swagger itself.

I rebased this from release/0.9.x - i.e. can a v0.9.3 be created with this please as we're not ready for the v1.0.x dropwizard yet.