### PR TITLE
Issue 33: remove setSerializationInclusion(JsonInclude.Include.NON_NULL)

### DIFF
--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -14,7 +14,6 @@
  */
 package io.federecio.dropwizard.swagger;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.assets.AssetsBundle;
@@ -58,9 +57,6 @@ public abstract class SwaggerBundle<T extends Configuration>
         new AssetsBundle("/swagger-static",
                 configurationHelper.getSwaggerUriPath(), null, "swagger-assets")
                         .run(environment);
-
-        environment.getObjectMapper()
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         swaggerBundleConfiguration.build(configurationHelper.getUrlPattern());
 


### PR DESCRIPTION
Enabling dropwizard's objectMapper JsonInclude.Include.NON_NULL is not pertinent to swagger or swagger-bundle operation and may adversely affecting applications' Jersey serialization.

Change-Id: I408235bfc03a118bbaf7132a42376dd1ef5e3c15