### PR TITLE
bump to dropwizard 1.0.0-rc2 and satisfy dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     </scm>
 
     <properties>
-        <dropwizard.version>0.9.2</dropwizard.version>
+        <dropwizard.version>1.0.0-rc2</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>

--- a/src/main/java/io/federecio/dropwizard/swagger/ConfigurationHelper.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/ConfigurationHelper.java
@@ -19,6 +19,8 @@ import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.server.ServerFactory;
 import io.dropwizard.server.SimpleServerFactory;
 
+import java.util.Optional;
+
 /**
  * Wrapper around Dropwizard's configuration and the bundle's config that
  * simplifies getting some information from them.
@@ -49,7 +51,7 @@ public class ConfigurationHelper {
 
         final ServerFactory serverFactory = configuration.getServerFactory();
 
-        final String rootPath;
+        final Optional<String> rootPath;
         if (serverFactory instanceof SimpleServerFactory) {
             rootPath = ((SimpleServerFactory) serverFactory)
                     .getJerseyRootPath();
@@ -58,7 +60,7 @@ public class ConfigurationHelper {
                     .getJerseyRootPath();
         }
 
-        return stripUrlSlashes(rootPath);
+        return stripUrlSlashes(rootPath.orElse("/"));
     }
 
     public String getUrlPattern() {

--- a/src/test/java/io/federecio/dropwizard/swagger/TestResource.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestResource.java
@@ -22,7 +22,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 
 /**
  * @author Federico Recio

--- a/src/test/java/io/federecio/dropwizard/swagger/selenium/auth/TestAuthenticator.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/selenium/auth/TestAuthenticator.java
@@ -14,10 +14,11 @@
  */
 package io.federecio.dropwizard.swagger.selenium.auth;
 
-import com.google.common.base.Optional;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import io.dropwizard.auth.PrincipalImpl;
+
+import java.util.Optional;
 
 public class TestAuthenticator implements Authenticator<String, PrincipalImpl> {
 
@@ -27,6 +28,6 @@ public class TestAuthenticator implements Authenticator<String, PrincipalImpl> {
         if ("secret".equals(token)) {
             return Optional.of(new PrincipalImpl(token));
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
For some  reason (accidently merge?) support for latest dropwizard was dropped from master.
There is a branch for supporting dropwizard 0.9.x - so imho master should get ready for latest dropwizard.