### PR TITLE
add the ability to remove swagger resource from the application context

### DIFF
--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -65,10 +65,12 @@ public abstract class SwaggerBundle<T extends Configuration>
 
         environment.jersey().register(new ApiListingResource());
         environment.jersey().register(new SwaggerSerializers());
-        environment.jersey().register(new SwaggerResource(
+        if(swaggerBundleConfiguration.isIncludeSwaggerResource()) {
+            environment.jersey().register(new SwaggerResource(
                 configurationHelper.getUrlPattern(),
                 swaggerBundleConfiguration.getSwaggerViewConfiguration(),
                 swaggerBundleConfiguration.getContextRoot()));
+        }
     }
 
     protected abstract SwaggerBundleConfiguration getSwaggerBundleConfiguration(

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
@@ -53,6 +53,7 @@ public class SwaggerBundleConfiguration {
     private String contextRoot = "/";
     private String[] schemes = new String[] { "http" };
     private Boolean enabled = true;
+    private Boolean includeSwaggerResource = true;
 
     /**
      * For most of the scenarios this property is not needed.
@@ -237,6 +238,16 @@ public class SwaggerBundleConfiguration {
     @JsonProperty
     public void setIsEnabled(final boolean isEnabled) {
         this.enabled = isEnabled;
+    }
+
+    @JsonProperty
+    public boolean isIncludeSwaggerResource() {
+        return includeSwaggerResource;
+    }
+
+    @JsonProperty
+    public void setIncludeSwaggerResource(final boolean include) {
+        this.includeSwaggerResource = include;
     }
 
     @JsonIgnore

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithSwaggerResourceDisabledTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithSwaggerResourceDisabledTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.federecio.dropwizard.swagger;
+
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.restassured.RestAssured;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hamcrest.core.StringContains;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class DefaultServerWithSwaggerResourceDisabledTest extends DropwizardCommonTest {
+
+    @ClassRule
+    public static final DropwizardAppRule<TestConfiguration> RULE = new DropwizardAppRule<TestConfiguration>(
+            TestApplication.class,
+            ResourceHelpers.resourceFilePath("test-default-without-swagger-resource.yaml"));
+
+    public DefaultServerWithSwaggerResourceDisabledTest() {
+        super(RULE.getLocalPort(), "/");
+    }
+
+    @Test
+    public void swaggerIsAvailable() throws Exception {
+        RestAssured.expect().statusCode(HttpStatus.OK_200)
+            .body(StringContains
+                .containsString(TestResource.OPERATION_DESCRIPTION))
+            .when().get(Path.from(basePath, "swagger.json"));
+        RestAssured.expect().statusCode(HttpStatus.NOT_FOUND_404).when()
+            .get(Path.from(basePath, "swagger"));
+        RestAssured.expect().statusCode(HttpStatus.NOT_FOUND_404).when()
+            .get(Path.from(basePath, "swagger") + "/");
+    }
+}

--- a/src/test/resources/test-default-without-swagger-resource.yaml
+++ b/src/test/resources/test-default-without-swagger-resource.yaml
@@ -1,0 +1,11 @@
+server:
+  type: default
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0
+swagger:
+  resourcePackage: io.federecio.dropwizard.swagger
+  includeSwaggerResource: False


### PR DESCRIPTION
For certain group of people the swagger UI is not needed in the application context because they have dedicated instances for swagger UI and it also exposes a potential security risks by opening the UI up to the world when the application context is exposed to the internet.  