### PR TITLE
Upgrade to Dropwizard 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.smoketurner.dropwizard</groupId>
         <artifactId>dropwizard-pom</artifactId>
-        <version>2.0.0-1</version>
+        <version>2.0.0-3</version>
     </parent>
 
     <groupId>com.smoketurner</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.smoketurner.dropwizard</groupId>
         <artifactId>dropwizard-pom</artifactId>
-        <version>1.3.17-1</version>
+        <version>2.0.0-1</version>
     </parent>
 
     <groupId>com.smoketurner</groupId>
@@ -77,6 +77,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
+            <version>2.29.1</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -68,14 +68,14 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
         new ConfigurationHelper(configuration, swaggerBundleConfiguration);
     new AssetsBundle(
             "/swagger-static", configurationHelper.getSwaggerUriPath(), null, "swagger-assets")
-        .run(environment);
+        .run(configuration, environment);
 
     new AssetsBundle(
             "/swagger-static/oauth2-redirect.html",
             configurationHelper.getOAuth2RedirectUriPath(),
             null,
             "swagger-oauth2-connect")
-        .run(environment);
+        .run(configuration, environment);
 
     swaggerBundleConfiguration.build(configurationHelper.getUrlPattern());
 

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
@@ -35,7 +35,7 @@ import io.swagger.jaxrs.config.BeanConfig;
 import io.swagger.models.Contact;
 import java.util.Arrays;
 import javax.annotation.Nullable;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 /**
  * For the meaning of all these properties please refer to Swagger documentation or {@link

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerTest.java
@@ -13,29 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//  Copyright (C) 2014 Federico Recio
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class, ResourceHelpers.resourceFilePath("test-default.yaml"));
 
   public DefaultServerTest() {

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithApiSelectorDisabledTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithApiSelectorDisabledTest.java
@@ -13,28 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithApiSelectorDisabledTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplicationWithApiSelectorDisabled.class,
           ResourceHelpers.resourceFilePath("test-default.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithApplicationContextPathAndRootPathSetTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithApplicationContextPathAndRootPathSetTest.java
@@ -13,29 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//  Copyright (C) 2014 Federico Recio
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithApplicationContextPathAndRootPathSetTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class,
           ResourceHelpers.resourceFilePath("test-default-context-and-root-path.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithApplicationContextPathSetTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithApplicationContextPathSetTest.java
@@ -13,29 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//  Copyright (C) 2014 Federico Recio
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithApplicationContextPathSetTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class,
           ResourceHelpers.resourceFilePath("test-default-context-path.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithAuthAndApiSelectorDisabledTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithAuthAndApiSelectorDisabledTest.java
@@ -13,28 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithAuthAndApiSelectorDisabledTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplicationWithAuthAndApiSelectorDisabled.class,
           ResourceHelpers.resourceFilePath("test-default.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithAuthDisabledTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithAuthDisabledTest.java
@@ -13,28 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithAuthDisabledTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplicationWithAuthDisabled.class,
           ResourceHelpers.resourceFilePath("test-default.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithContactTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithContactTest.java
@@ -13,33 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.restassured.RestAssured;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.core.StringContains;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithContactTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class, ResourceHelpers.resourceFilePath("test-default-contact.yaml"));
 
   public DefaultServerWithContactTest() {

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithCustomTemplateTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithCustomTemplateTest.java
@@ -13,28 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithCustomTemplateTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplicationWithCustomTemplate.class,
           ResourceHelpers.resourceFilePath("test-default.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithNoSwaggerTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithNoSwaggerTest.java
@@ -30,15 +30,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithNoSwaggerTest extends DropwizardNoSwaggerTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class, ResourceHelpers.resourceFilePath("test-default-disabled.yaml"));
 
   public DefaultServerWithNoSwaggerTest() {

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithPathSetProgramaticallyTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithPathSetProgramaticallyTest.java
@@ -13,29 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//  Copyright (C) 2014 Federico Recio
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithPathSetProgramaticallyTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplicationWithPathSetProgramatically.class,
           ResourceHelpers.resourceFilePath("test-default-with-path-set-programatically.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithRootPathSetTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithRootPathSetTest.java
@@ -13,29 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//  Copyright (C) 2014 Federico Recio
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithRootPathSetTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class, ResourceHelpers.resourceFilePath("test-default-root-path.yaml"));
 
   public DefaultServerWithRootPathSetTest() {

--- a/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithSwaggerResourceDisabledTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DefaultServerWithSwaggerResourceDisabledTest.java
@@ -13,32 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
- *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.restassured.RestAssured;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.core.StringContains;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class DefaultServerWithSwaggerResourceDisabledTest extends DropwizardCommonTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class,
           ResourceHelpers.resourceFilePath("test-default-without-swagger-resource.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DropwizardCommonTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DropwizardCommonTest.java
@@ -37,7 +37,7 @@ import java.util.List;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class DropwizardCommonTest {
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DropwizardNoSwaggerTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DropwizardNoSwaggerTest.java
@@ -28,7 +28,7 @@ package io.federecio.dropwizard.swagger;
 
 import io.restassured.RestAssured;
 import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class DropwizardNoSwaggerTest extends DropwizardCommonTest {
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DropwizardTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DropwizardTest.java
@@ -30,7 +30,7 @@ package io.federecio.dropwizard.swagger;
 import io.restassured.RestAssured;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.core.StringContains;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class DropwizardTest extends DropwizardCommonTest {
 

--- a/src/test/java/io/federecio/dropwizard/swagger/SimpleServerTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/SimpleServerTest.java
@@ -28,14 +28,15 @@
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class SimpleServerTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class, ResourceHelpers.resourceFilePath("test-simple.yaml"));
 
   public SimpleServerTest() {

--- a/src/test/java/io/federecio/dropwizard/swagger/SimpleServerWithApplicationContextPathAndRootPathSetTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/SimpleServerWithApplicationContextPathAndRootPathSetTest.java
@@ -28,14 +28,15 @@
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class SimpleServerWithApplicationContextPathAndRootPathSetTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class,
           ResourceHelpers.resourceFilePath("test-simple-with-context-and-root-path.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/SimpleServerWithApplicationContextPathSetTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/SimpleServerWithApplicationContextPathSetTest.java
@@ -28,14 +28,15 @@
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class SimpleServerWithApplicationContextPathSetTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class,
           ResourceHelpers.resourceFilePath("test-simple-with-context-path.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/SimpleServerWithRootPathSetTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/SimpleServerWithRootPathSetTest.java
@@ -28,14 +28,15 @@
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit.DropwizardAppRule;
-import org.junit.ClassRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(DropwizardExtensionsSupport.class)
 public class SimpleServerWithRootPathSetTest extends DropwizardTest {
 
-  @ClassRule
-  public static final DropwizardAppRule<TestConfiguration> RULE =
-      new DropwizardAppRule<TestConfiguration>(
+  private static DropwizardAppExtension<TestConfiguration> RULE =
+      new DropwizardAppExtension<>(
           TestApplication.class,
           ResourceHelpers.resourceFilePath("test-simple-with-root-path.yaml"));
 

--- a/src/test/java/io/federecio/dropwizard/swagger/TestApplication.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestApplication.java
@@ -48,6 +48,6 @@ public class TestApplication extends Application<TestConfiguration> {
 
   @Override
   public void run(TestConfiguration configuration, Environment environment) throws Exception {
-    environment.jersey().register(new TestResource());
+    environment.jersey().register(TestResource.class);
   }
 }

--- a/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithApiSelectorDisabled.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithApiSelectorDisabled.java
@@ -52,6 +52,6 @@ public class TestApplicationWithApiSelectorDisabled extends Application<TestConf
 
   @Override
   public void run(TestConfiguration configuration, Environment environment) throws Exception {
-    environment.jersey().register(new TestResource());
+    environment.jersey().register(TestResource.class);
   }
 }

--- a/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithAuthAndApiSelectorDisabled.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithAuthAndApiSelectorDisabled.java
@@ -54,6 +54,6 @@ public class TestApplicationWithAuthAndApiSelectorDisabled extends Application<T
 
   @Override
   public void run(TestConfiguration configuration, Environment environment) throws Exception {
-    environment.jersey().register(new TestResource());
+    environment.jersey().register(TestResource.class);
   }
 }

--- a/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithAuthDisabled.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithAuthDisabled.java
@@ -54,6 +54,6 @@ public class TestApplicationWithAuthDisabled extends Application<TestConfigurati
 
   @Override
   public void run(TestConfiguration configuration, Environment environment) throws Exception {
-    environment.jersey().register(new TestResource());
+    environment.jersey().register(TestResource.class);
   }
 }

--- a/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithCustomTemplate.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithCustomTemplate.java
@@ -57,6 +57,6 @@ public class TestApplicationWithCustomTemplate extends Application<TestConfigura
 
   @Override
   public void run(TestConfiguration configuration, Environment environment) throws Exception {
-    environment.jersey().register(new TestResource());
+    environment.jersey().register(TestResource.class);
   }
 }

--- a/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithPathSetProgramatically.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithPathSetProgramatically.java
@@ -61,6 +61,6 @@ public class TestApplicationWithPathSetProgramatically extends Application<TestC
   @Override
   public void run(TestConfiguration configuration, final Environment environment) throws Exception {
     ((DefaultServerFactory) configuration.getServerFactory()).setJerseyRootPath(BASE_PATH + "/*");
-    environment.jersey().register(new TestResource());
+    environment.jersey().register(TestResource.class);
   }
 }


### PR DESCRIPTION
Fixes #155

All of the tests need to be updated to JUnit5 for this to compile and pass.  Unfortunately I'm not longer using this plugin, so if anyone would like to help with this effort, it would be very much appreciated.