### PR TITLE
Exclude javax.validation:validation-api from swagger-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <url>http://github.com/smoketurner/dropwizard-swagger</url>
         <tag>HEAD</tag>
     </scm>
-    
+
     <dependencyManagement>
       <dependencies>
         <dependency>
@@ -93,6 +93,13 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jersey2-jaxrs</artifactId>
             <version>1.6.2</version>
+            <!-- Causes runtime issues with jakarta.validation:validation-api in dropwizard-core -->
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Dropwizard-core 2.x brings in jakarta.validation:validation-api which causes runtime conflicts with javax.validation:validation-api because both libraries use the same package/class names.

Once swagger is updated to 2.x this will not be needed, however, that is a much bigger change.