### PR TITLE
Allow requestInterceptor to keep its default value when you're not using custom javascript

### DIFF
--- a/src/main/resources/io/federecio/dropwizard/swagger/index.ftl
+++ b/src/main/resources/io/federecio/dropwizard/swagger/index.ftl
@@ -67,7 +67,7 @@
         ],
         oauth2RedirectUrl: window.location.protocol + "//" + window.location.host + "${contextPath}/oauth2-redirect.html",
         layout: "StandaloneLayout",
-        requestInterceptor: (typeof customRequestInterceptor == 'function' ? customRequestInterceptor : null)
+        requestInterceptor: (typeof customRequestInterceptor == 'function' ? customRequestInterceptor : (a => a))
       });
 
       ui.initOAuth({

--- a/src/main/resources/io/federecio/dropwizard/swagger/index.ftl
+++ b/src/main/resources/io/federecio/dropwizard/swagger/index.ftl
@@ -67,7 +67,9 @@
         ],
         oauth2RedirectUrl: window.location.protocol + "//" + window.location.host + "${contextPath}/oauth2-redirect.html",
         layout: "StandaloneLayout",
-        requestInterceptor: (typeof customRequestInterceptor == 'function' ? customRequestInterceptor : (a => a))
+        <#if customJavascriptPath??>
+        requestInterceptor: (typeof customRequestInterceptor == 'function' ? customRequestInterceptor : null)
+        </#if>
       });
 
       ui.initOAuth({


### PR DESCRIPTION
Fixes #210

Not sure if requestInterceptor should ever be null? Because that will always give errors.

On the other hand, now it would only be null when the user has tried to add custom javascript and failed, which is kind of a good reason to show errors instead of failing silently...