### PR TITLE
Scheme should default to empty array

### DIFF
--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
@@ -79,7 +79,7 @@ public class SwaggerBundleConfiguration {
   @Nullable private String host;
 
   private String contextRoot = "/";
-  private String[] schemes = new String[] {"http"};
+  private String[] schemes = new String[] {};
   private boolean enabled = true;
   private boolean includeSwaggerResource = true;
 


### PR DESCRIPTION
Our project is sometimes served on `http` and sometimes `https`. If you don't specify a schema then swagger will default to using the transport used to serve up the web page - which is always the correct choice. If you specify schemas the user must manually choose.